### PR TITLE
typo: terraform destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Esta actividad consiste en:
    ```bash
    terraform plan
    terraform apply
-   terraform apply
+   terraform destroy
 ## CONTRIBUCIONES
 
 Contribuciones son bienvenidas! Revisa nuestra [Guía de Contribuciones](./docs/CONTRIBUTING.md)


### PR DESCRIPTION
Replaced 'terraform apply' with 'terraform destroy' in commands section.